### PR TITLE
refactor(compose): use Docker Hub image for app, remove build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    build: .
+    image: cemakan/url-shortener:latest
     container_name: shortener
     env_file: [.env]
     labels:


### PR DESCRIPTION
Changed docker-compose to use the app image from Docker Hub instead of building it locally.

- Now uses cemakan/url-shortener image.
- Removed the build: . line from compose.
- Makes deployment faster and simpler.
- Good for CI/CD pipelines.

Tested:  
- docker compose up works fine with the Docker Hub image.
- The app and other services are working as before.